### PR TITLE
Add missing dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  [org.flatland/ordered "1.5.2"]
                  [org.clojure/tools.macro "0.1.5"]
                  [emf-xsd-sdk "2.10.1"]
+                 [im.chit/vinyasa.inject "0.3.0"]
                  [inflections "0.9.13" :exclusions [org.clojure/clojure]]]
   :profiles {:dev {:source-paths ["dev"]}}
   ;; Don't put version control dirs into the jar


### PR DESCRIPTION
It seems vinyasa.inject is needed and was missing from the project.clj file. I still get some errors at repl start. Not sure why. Just the first try. For example:

Reflection warning, clojure/tools/nrepl/server.clj:140:28 - call to java.net.InetSocketAddress ctor can't be resolved.
Reflection warning, complete/core.clj:38:14 - reference to field getName on java.lang.Object can't be resolved.
...
